### PR TITLE
ci: pass Harbor secrets explicitly to reusable dockerbuild workflow so other organizations can re-use them

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -37,6 +37,11 @@ on:
         type: string
         default: "."
         required: false
+    secrets:
+      HARBOR_HOST:
+        required: true
+      HARBOR_CREDENTIALS:
+        required: true
 
 jobs:
   setup:


### PR DESCRIPTION
This makes the same docker workflow work from forks. Before, the workflow was not able to access secrets from other organizations. We need to be explicit about secrets.

Before, the workflow would complain, as per this example run:

```
[](https://github.com/arnemileswinter/facis-dcs/actions/runs/28652511704/job/84973741194#step:4:1)Run git clone [https://github.com/eclipse-xfsc/dev-ops.git](https://github.com/eclipse-xfsc/dev-ops.git) devops

[](https://github.com/arnemileswinter/facis-dcs/actions/runs/28652511704/job/84973741194#step:4:49)Cloning into 'devops'...

[](https://github.com/arnemileswinter/facis-dcs/actions/runs/28652511704/job/84973741194#step:4:50)clone successfull

[](https://github.com/arnemileswinter/facis-dcs/actions/runs/28652511704/job/84973741194#step:4:51)Fehler: Umgebungsvariable HARBOR_CREDENTIALS ist nicht gesetzt.

[](https://github.com/arnemileswinter/facis-dcs/actions/runs/28652511704/job/84973741194#step:4:52)Error: Process completed with exit code 1.
```