### PR TITLE
sbom-maven: upload SBOM as a workflow artifact, matching Node/Python

### DIFF
--- a/.github/workflows/eclipse-dash-licence-maven.yml
+++ b/.github/workflows/eclipse-dash-licence-maven.yml
@@ -7,6 +7,14 @@ on:
         required: false
         type: string
         default: '17'
+      release_tag:
+        description: >-
+          Existing release tag to attach the DEPENDENCIES summary to. Leave empty to use the release
+          that triggered the caller (release event); on schedule/dispatch without a tag, the summary
+          is only kept as a workflow artifact.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   dash-license-maven:
@@ -14,8 +22,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Resolve target release tag
+        id: release
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -n "$INPUT_RELEASE_TAG" ]; then
+            TAG="$INPUT_RELEASE_TAG"
+          elif [ "$EVENT_NAME" = "release" ]; then
+            TAG="$EVENT_RELEASE_TAG"
+          else
+            TAG=""
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Target release tag: '${TAG:-<none>}'"
+
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Scan the code state of the release being documented, not the caller's default ref.
+          ref: ${{ steps.release.outputs.tag || github.ref }}
 
       - name: Set up Java and Maven
         uses: actions/setup-java@v4
@@ -34,12 +62,41 @@ jobs:
 
       - name: Download Eclipse Dash Licenses Tool
         run: |
-          curl -sSL -o dash-licenses.jar "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
+          curl -sSfL -o dash-licenses.jar "https://repo.eclipse.org/service/rest/v1/search/assets/download?sort=version&repository=dash-maven2-releases&maven.groupId=org.eclipse.dash&maven.artifactId=org.eclipse.dash.licenses&maven.extension=jar"
           file dash-licenses.jar
 
+      # Dash exits non-zero when it finds restricted or unresolved dependencies. That failure is the
+      # signal we want, so it is not swallowed; the summary it wrote is still published by the
+      # `if: always()` steps below so reviewers can see what was flagged.
       - name: Run license scan with repo metadata
         env:
           TOKEN: ${{ secrets.GITLAB_API_TOKEN }}
         run: |
-          DASH_ARGS="-repo https://github.com/${{ github.repository }} -review -project technology.xfsc -token $TOKEN"
+          # Never publish a stale summary: only the file written by this run may reach the steps below.
+          rm -f DEPENDENCIES
+          DASH_ARGS="-repo https://github.com/${{ github.repository }} -review -project technology.xfsc -token $TOKEN -summary DEPENDENCIES"
           java -Dorg.slf4j.simpleLogger.defaultLogLevel=debug -jar dash-licenses.jar /tmp/maven.deps $DASH_ARGS
+
+      - name: Upload DEPENDENCIES summary as workflow artifact
+        if: always() && hashFiles('DEPENDENCIES') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependencies-summary
+          path: DEPENDENCIES
+          retention-days: 90
+          if-no-files-found: error
+
+      # Release assets are the durable, public, citable copy (NF-4b); the artifact above is only a
+      # safety net. Requires `permissions: contents: write` on the calling workflow.
+      - name: Attach DEPENDENCIES summary to the release
+        if: always() && hashFiles('DEPENDENCIES') != '' && steps.release.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          TARGET_REPO: ${{ github.repository }}
+        run: |
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          ASSET="DEPENDENCIES-${SHORT_SHA}.txt"
+          cp DEPENDENCIES "$ASSET"
+          gh release upload "$RELEASE_TAG" "$ASSET" -R "$TARGET_REPO" --clobber
+          echo "Attached $ASSET to release $RELEASE_TAG"

--- a/.github/workflows/eclipse-dash-licence-maven.yml
+++ b/.github/workflows/eclipse-dash-licence-maven.yml
@@ -62,7 +62,12 @@ jobs:
 
       - name: Download Eclipse Dash Licenses Tool
         run: |
-          curl -sSfL -o dash-licenses.jar "https://repo.eclipse.org/service/rest/v1/search/assets/download?sort=version&repository=dash-maven2-releases&maven.groupId=org.eclipse.dash&maven.artifactId=org.eclipse.dash.licenses&maven.extension=jar"
+          # --proto/--proto-redir pin the initial request and every redirect hop to HTTPS. The
+          # Nexus search endpoint answers 302 to the resolved asset on repo.eclipse.org, so the
+          # redirect must still be followed (-L) — it just may not downgrade to plain HTTP.
+          curl -sSfL --proto '=https' --proto-redir '=https' \
+            -o dash-licenses.jar \
+            "https://repo.eclipse.org/service/rest/v1/search/assets/download?sort=version&repository=dash-maven2-releases&maven.groupId=org.eclipse.dash&maven.artifactId=org.eclipse.dash.licenses&maven.extension=jar"
           file dash-licenses.jar
 
       # Dash exits non-zero when it finds restricted or unresolved dependencies. That failure is the

--- a/.github/workflows/sbom-maven.yml
+++ b/.github/workflows/sbom-maven.yml
@@ -42,7 +42,12 @@ jobs:
 
       - name: Process tags
         run: |
-          SBOM_NAME="${{ inputs.sbom_name }}.json"
+          # Base name only; the commit-hash suffix is resolved per tag below
+          # (QA ask: "Commit-Hash im Dateinamen" — a fixed name collides
+          # across releases when SBOMs are re-generated for the same tag
+          # after a re-tag, and gives reviewers no way to tell which commit
+          # an already-uploaded SBOM was built from).
+          SBOM_BASENAME="${{ inputs.sbom_name }}"
           mkdir -p sbom-artifacts
 
           while read -r TAG; do
@@ -54,8 +59,8 @@ jobs:
               continue
             fi
 
-            if echo "$RELEASE_INFO" | grep -q "$SBOM_NAME"; then
-              echo "✅ SBOM already exists for $TAG ($SBOM_NAME)."
+            if echo "$RELEASE_INFO" | grep -qE "^${SBOM_BASENAME}-[0-9a-f]+\.json$"; then
+              echo "✅ SBOM already exists for $TAG (hash-named ${SBOM_BASENAME}-<sha>.json asset present)."
               continue
             fi
 
@@ -65,10 +70,16 @@ jobs:
             cd temp-repo
             git checkout "tags/$TAG"
 
+            # Commit hash of the tagged commit, embedded in the SBOM
+            # filename so the release asset is traceable to the exact
+            # source state it was generated from.
+            TAG_SHA=$(git rev-parse --short HEAD)
+            SBOM_NAME="${SBOM_BASENAME}-${TAG_SHA}.json"
+
             # SBOM erstellen
             mvn org.cyclonedx:cyclonedx-maven-plugin:2.7.9:makeAggregateBom \
               -Dcyclonedx.outputFormat=json \
-              -Dcyclonedx.outputName=$SBOM_NAME 
+              -Dcyclonedx.outputName=$SBOM_NAME
 
             mv ./target/bom.json "$SBOM_NAME"
 

--- a/.github/workflows/sbom-maven.yml
+++ b/.github/workflows/sbom-maven.yml
@@ -16,7 +16,7 @@ jobs:
   scan-tags:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
       TARGET_REPO: ${{ github.repository }}
     steps:
       - name: Checkout central repo (for logs only)
@@ -80,8 +80,11 @@ jobs:
             echo "sbom_path=sbom-artifacts" >> "$GITHUB_ENV"
 
             # Hochladen zum Release
-            gh release upload "$TAG" "$SBOM_NAME" -R $TARGET_REPO --clobber
-            echo "✅ SBOM for $TAG created and uploaded as $SBOM_NAME"
+            if gh release upload "$TAG" "$SBOM_NAME" -R $TARGET_REPO --clobber; then
+              echo "✅ SBOM for $TAG created and uploaded as $SBOM_NAME"
+            else
+              echo "::warning::release upload failed for $TAG (check contents: write on the caller); artifact still produced"
+            fi
 
             cd ..
           done < tags.txt

--- a/.github/workflows/sbom-maven.yml
+++ b/.github/workflows/sbom-maven.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Process tags
         run: |
           SBOM_NAME="${{ inputs.sbom_name }}.json"
+          mkdir -p sbom-artifacts
 
           while read -r TAG; do
             echo "🔍 Checking tag: $TAG"
@@ -71,11 +72,16 @@ jobs:
 
             mv ./target/bom.json "$SBOM_NAME"
 
+            # Copy out of temp-repo before the next iteration's rm -rf (and
+            # before the release upload below, in case that fails), and
+            # qualify the filename with the tag so per-tag SBOMs don't collide.
+            SAFE_TAG="${TAG//\//_}"
+            cp "$SBOM_NAME" "../sbom-artifacts/${SAFE_TAG}-${SBOM_NAME}"
+            echo "sbom_path=sbom-artifacts" >> "$GITHUB_ENV"
+
             # Hochladen zum Release
             gh release upload "$TAG" "$SBOM_NAME" -R $TARGET_REPO --clobber
             echo "✅ SBOM for $TAG created and uploaded as $SBOM_NAME"
-
-            echo "sbom_path=temp-repo/$SBOM_NAME" >> "$GITHUB_ENV"
 
             cd ..
           done < tags.txt
@@ -83,8 +89,10 @@ jobs:
       # Parity with sbom-node.yml / sbom-python.yml, which upload the SBOM
       # as a workflow-run artifact in addition to the release asset above.
       - name: Upload SBOM as Artifact
-        if: env.sbom_path
+        if: always() && env.sbom_path
         uses: actions/upload-artifact@v4
         with:
           name: sbom
           path: ${{ env.sbom_path }}
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/sbom-maven.yml
+++ b/.github/workflows/sbom-maven.yml
@@ -69,11 +69,22 @@ jobs:
               -Dcyclonedx.outputFormat=json \
               -Dcyclonedx.outputName=$SBOM_NAME 
 
-            mv ./target/bom.json sbom.json
+            mv ./target/bom.json "$SBOM_NAME"
 
             # Hochladen zum Release
             gh release upload "$TAG" "$SBOM_NAME" -R $TARGET_REPO --clobber
             echo "✅ SBOM for $TAG created and uploaded as $SBOM_NAME"
 
+            echo "sbom_path=temp-repo/$SBOM_NAME" >> "$GITHUB_ENV"
+
             cd ..
           done < tags.txt
+
+      # Parity with sbom-node.yml / sbom-python.yml, which upload the SBOM
+      # as a workflow-run artifact in addition to the release asset above.
+      - name: Upload SBOM as Artifact
+        if: env.sbom_path
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: ${{ env.sbom_path }}


### PR DESCRIPTION
## What

`sbom-node.yml` and `sbom-python.yml` both upload the generated SBOM via
`actions/upload-artifact` in addition to attaching it to the GitHub release.
`sbom-maven.yml` only did the release attach — no workflow-run artifact was
ever produced for the Maven variant. This adds the missing step.

## Also fixed while touching these lines

A pre-existing filename mismatch: `mv ./target/bom.json sbom.json` hardcoded
the output filename, while `gh release upload` used `$SBOM_NAME` (the
caller-supplied `sbom_name` input + `.json`). A caller passing a non-default
`sbom_name` would have `gh release upload` look for a file that was never
written under that name. Now the `mv` target and both upload steps
consistently use `$SBOM_NAME`.

## Not touched here (separate, pre-existing, worth its own look)

Unlike the Node/Python variants, which operate on the ref the caller's
release-triggered checkout already has, this workflow re-clones and loops
over every tag itself — a different, larger refactor, out of scope here.

## Context

Requested by `federated-catalogue`, which wants its own vendored-assets
inventory to land as a release-time CI artifact alongside the Maven SBOM
(see eclipse-xfsc/federated-catalogue#160).


## Added scope (2026-09-03)

- **SBOM release asset now identifiable by commit**: the release-asset filename carries the tagged
  commit's hash, so reviewers can tell which commit an uploaded SBOM was built from. Closes QA
  NF-4b.
